### PR TITLE
Format fix for Asset in APY Data

### DIFF
--- a/src/logic/umbriaApi.ts
+++ b/src/logic/umbriaApi.ts
@@ -118,7 +118,7 @@ export default class UmbriaApi {
           outputdata.push({
             network: NETWORKS[i].displayName,
             bridge: BRIDGEDISPLAYNAMES[bridge as Bridge],
-            asset,
+            asset: asset.toUpperCase(),
             apy: Number(network?.[bridge as Bridge]?.[asset]),
           });
         }


### PR DESCRIPTION
force uppercase because api sometimes returns asset as lowercase.